### PR TITLE
avoid run time allocations

### DIFF
--- a/lib/rack/pratchett.rb
+++ b/lib/rack/pratchett.rb
@@ -5,9 +5,9 @@ module Rack
     end
 
     def call(env)
-      status, headers, body = @app.call(env)
-      headers['X-Clacks-Overhead'] = 'GNU Terry Pratchett'
-      [status, headers, body]
+      result = @app.call(env)
+      result[1]['X-Clacks-Overhead'.freeze] = 'GNU Terry Pratchett'.freeze
+      result
     end
   end
 end


### PR DESCRIPTION
Previously the middleware created three objects per request, with this patch and a recent Ruby it will not allocate any objects after initialisation.
