### PR TITLE
Bump dependency versions to patch security issues

### DIFF
--- a/rack-pratchett.gemspec
+++ b/rack-pratchett.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   #   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
   # end
 
-  spec.add_development_dependency 'bundler', "~> 1.8"
-  spec.add_development_dependency 'rake', "~> 10.0"
+  spec.add_development_dependency 'bundler', "~> 2.5"
+  spec.add_development_dependency 'rake', "~> 13"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rack'
 end


### PR DESCRIPTION
Hi @rmcfadzean, not sure if you're still keeping an eye on this, but if you are – there were some security alerts on the versions of bundler and rake in this gem's gemspec, so here is a small PR to update them. 😅 